### PR TITLE
Cleanup TCP module

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -5,7 +5,7 @@
 //! [portability guidelines] are followed, the behavior should be identical no
 //! matter the target platform.
 //!
-//! [portability guidelines]: ../struct.Poller.html#portability
+//! [portability guidelines]: ../poll/struct.Poller.html#portability
 
 mod tcp;
 mod udp;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -80,20 +80,6 @@ impl TcpStream {
         sys::TcpStream::connect(stream, &addr).map(|inner| TcpStream { inner })
     }
 
-    /// Creates a new `TcpStream` from a standard `net::TcpStream`.
-    ///
-    /// This function is intended to be used to wrap a TCP stream from the
-    /// standard library in the mio equivalent. The conversion here will
-    /// automatically set `stream` to nonblocking and the returned object should
-    /// be ready to get associated with an event loop.
-    ///
-    /// Note that the TCP stream here will not have `connect` called on it, so
-    /// it should already be connected via some other means (be it manually, the
-    /// `net2` crate, or the standard library).
-    pub fn from_std_stream(stream: net::TcpStream) -> io::Result<TcpStream> {
-        sys::TcpStream::from_std_stream(stream).map(|inner| TcpStream { inner })
-    }
-
     /// Returns the socket address of the remote peer of this TCP connection.
     pub fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         self.inner.peer_addr()
@@ -308,10 +294,7 @@ impl TcpListener {
     ///
     /// [`WouldBlock`]: https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.WouldBlock
     pub fn accept(&mut self) -> io::Result<(TcpStream, SocketAddr)> {
-        self.inner.accept().and_then(|(stream, addr)| {
-            let stream = TcpStream::from_std_stream(stream)?;
-            Ok((stream, addr))
-        })
+        self.inner.accept().map(|(inner, addr)| (TcpStream{ inner }, addr))
     }
 
     /// Returns the local socket address of this listener.

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -279,56 +279,6 @@ impl FromRawFd for TcpStream {
 /// #     try_main().unwrap();
 /// # }
 /// ```
-///
-/// Using the [`net2`] crate to create a listener and change settings on the
-/// accepted incoming connection.
-///
-/// ```
-/// extern crate net2;
-///
-/// # extern crate mio_st;
-/// # use std::error::Error;
-/// # fn try_main() -> Result<(), Box<Error>> {
-/// use std::time::Duration;
-/// use std::net::SocketAddr;
-///
-/// use mio_st::net::{TcpListener, TcpStream};
-/// use net2::{self, TcpStreamExt};
-///
-/// // Create a new `net2` `TcpBuilder`.
-/// let builder = net2::TcpBuilder::new_v4()?;
-///
-/// // Bind the tcp socket and start listening, this will return a
-/// // `std::net::TcpListener`.
-/// let addr: SocketAddr = "127.0.0.1:8002".parse()?;
-/// let std_listener = builder.bind(addr)?.listen(128)?;
-///
-/// // Convert the listener into an mio listener.
-/// let mut mio_listener = TcpListener::from_std_listener(std_listener)?;
-///
-/// // Use `mio_listener` as normal, such as registering it with poll, etc.
-///
-/// // This may return a `WouldBlock` error.
-/// # (|| -> ::std::io::Result<()> {
-/// let (std_stream, addr) = mio_listener.accept_std()?;
-///
-/// // Use net2's `TcpStreamExt` trait to modifiy the receiving buffer size.
-/// std_stream.set_recv_buffer_size(4 * 1024)?;
-///
-/// // Now convert the stream into a mio stream, set it non-blocking mode etc.
-/// let mio_stream = TcpStream::from_std_stream(std_stream)?;
-///
-/// // Now the `mio_stream` can be used as normal.
-/// # drop(mio_stream);
-/// # Ok(())
-/// # })();
-/// #     Ok(())
-/// # }
-/// #
-/// # fn main() {
-/// #     try_main().unwrap();
-/// # }
-/// ```
 #[derive(Debug)]
 pub struct TcpListener {
     inner: sys::TcpListener,
@@ -337,35 +287,8 @@ pub struct TcpListener {
 impl TcpListener {
     /// Convenience method to bind a new TCP listener to the specified address
     /// to receive new connections.
-    ///
-    /// This function will take the following steps:
-    ///
-    /// 1. Create a new TCP socket.
-    /// 2. Set the `SO_REUSEADDR` option on the socket.
-    /// 3. Bind the socket to the specified address.
-    /// 4. Call `listen` on the socket to prepare it to receive new connections.
-    pub fn bind(addr: SocketAddr) -> io::Result<TcpListener> {
-        let socket = match addr {
-            SocketAddr::V4(..) => TcpBuilder::new_v4(),
-            SocketAddr::V6(..) => TcpBuilder::new_v6(),
-        }?;
-
-        if cfg!(unix) {
-            let _ = socket.reuse_address(true)?;
-        }
-
-        let listener = socket.bind(addr)?.listen(128)?;
-        TcpListener::from_std_listener(listener)
-    }
-
-    /// Creates a new `TcpListener` from an instance of a
-    /// `std::net::TcpListener` type.
-    ///
-    /// This function will set the `listener` provided into nonblocking mode,
-    /// and otherwise the listener will just be wrapped up in an mio listener
-    /// ready to accept new connections and become associated with `Poller`.
-    pub fn from_std_listener(listener: net::TcpListener) -> io::Result<TcpListener> {
-        sys::TcpListener::new(listener).map(|inner| TcpListener { inner })
+    pub fn bind(address: SocketAddr) -> io::Result<TcpListener> {
+        sys::TcpListener::new(address).map(|inner| TcpListener { inner })
     }
 
     /// Accepts a new `TcpStream`.

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -10,10 +10,13 @@ use poll::{Poller, PollCalled, PollOption};
 
 /// A non-blocking TCP stream between a local socket and a remote socket.
 ///
-/// If fine-grained control over the creation of the socket is desired, you can
-/// use `net2::TcpBuilder` to configure a socket and then pass its socket to
-/// `TcpStream::connect_stream` to transfer ownership into mio and schedule the
-/// connect operation.
+/// This works much like the `TcpStream` in the standard library, but the
+/// [`Read`] and [`Write`] implementation don't block and instead return a
+/// [`WouldBlock`] error.
+///
+/// [`Read`]: #impl-Read
+/// [`Write`]: #impl-Write
+/// [`WouldBlock`]: https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.WouldBlock
 ///
 /// # Examples
 ///
@@ -206,9 +209,11 @@ impl FromRawFd for TcpStream {
 /// A TCP socket listener.
 ///
 /// This works much like the `TcpListener` in the standard library, but this
-/// doesn't block when calling [`accept`].
+/// doesn't block when calling [`accept`] and instead return [`WouldBlock`]
+/// error.
 ///
 /// [`accept`]: #method.accept
+/// [`WouldBlock`]: https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.WouldBlock
 ///
 /// # Examples
 ///

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -239,15 +239,12 @@ impl FromRawFd for TcpStream {
     }
 }
 
-/// A structure representing a socket listener.
+/// A TCP socket listener.
 ///
-/// If fine-grained control over the binding and listening process for a socket
-/// is desired then use the `net2::TcpBuilder` methods, in the [`net2`] crate.
-/// This can be used in combination with the [`TcpListener::from_std_listener`]
-/// method to transfer ownership into mio. Also see the second example below.
+/// This works much like the `TcpListener` in the standard library, but this
+/// doesn't block when calling [`accept`].
 ///
-/// [`net2`]: https://crates.io/crates/net2
-/// [`TcpListener::from_std_listener`]: #method.from_std_listener
+/// [`accept`]: #method.accept
 ///
 /// # Examples
 ///
@@ -267,7 +264,7 @@ impl FromRawFd for TcpStream {
 /// let mut events = Events::new();
 ///
 /// // Register the socket with `Poller`
-/// poll.register(&mut listener, EventedId(0), Ready::WRITABLE, PollOption::Edge)?;
+/// poll.register(&mut listener, EventedId(0), Ready::all(), PollOption::Edge)?;
 ///
 /// poll.poll(&mut events, Some(Duration::from_millis(100)))?;
 ///

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -4,8 +4,6 @@ use std::net::{self, Shutdown, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::time::Duration;
 
-use net2::TcpBuilder;
-
 use sys;
 use event::{Evented, EventedId, Ready};
 use poll::{Poller, PollCalled, PollOption};
@@ -57,27 +55,7 @@ impl TcpStream {
     /// Create a new TCP stream and issue a non-blocking connect to the
     /// specified address.
     pub fn connect(addr: SocketAddr) -> io::Result<TcpStream> {
-        let sock = match addr {
-            SocketAddr::V4(..) => TcpBuilder::new_v4(),
-            SocketAddr::V6(..) => TcpBuilder::new_v6(),
-        }?;
-        TcpStream::connect_stream(sock.to_tcp_stream()?, addr)
-    }
-
-    /// Creates a new `TcpStream` from the pending socket inside the given
-    /// `std::net::TcpBuilder`, connecting it to the address specified.
-    ///
-    /// This constructor allows configuring the socket before it's actually
-    /// connected, and this function will transfer ownership to the returned
-    /// `TcpStream` if successful. An unconnected `TcpStream` can be created
-    /// with the `net2::TcpBuilder` type (and also configured via that route).
-    ///
-    /// The platform specific behavior of this function looks like:
-    ///
-    /// * On Unix, the socket is placed into nonblocking mode and then a
-    ///   `connect` call is issued.
-    pub fn connect_stream(stream: net::TcpStream, addr: SocketAddr) -> io::Result<TcpStream> {
-        sys::TcpStream::connect(stream, &addr).map(|inner| TcpStream { inner })
+        sys::TcpStream::connect(addr).map(|inner| TcpStream { inner })
     }
 
     /// Returns the socket address of the remote peer of this TCP connection.

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -288,6 +288,15 @@ impl TcpListener {
         sys::TcpListener::new(address).map(|inner| TcpListener { inner })
     }
 
+    /// Create a independently owned handle to the underlying socket.
+    ///
+    /// The returned `TcpListener` is a reference to the same socket as `self`.
+    /// Both handles can be used to accept incoming connections and options set
+    /// on one listener will affect the other.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        self.inner.try_clone().map(|inner| TcpListener { inner })
+    }
+
     /// Accepts a new `TcpStream`.
     ///
     /// This may return an [`WouldBlock`] error, this means a stream may be
@@ -327,15 +336,6 @@ impl TcpListener {
     /// calls.
     pub fn take_error(&mut self) -> io::Result<Option<io::Error>> {
         self.inner.take_error()
-    }
-
-    /// Create a independently owned handle to the underlying socket.
-    ///
-    /// The returned `TcpListener` is a reference to the same socket as `self`.
-    /// Both handles can be used to accept incoming connections and options set
-    /// on one listener will affect the other.
-    pub fn try_clone(&self) -> io::Result<Self> {
-        self.inner.try_clone().map(|inner| TcpListener { inner })
     }
 }
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -379,19 +379,10 @@ impl TcpListener {
     ///
     /// [`WouldBlock`]: https://doc.rust-lang.org/nightly/std/io/enum.ErrorKind.html#variant.WouldBlock
     pub fn accept(&mut self) -> io::Result<(TcpStream, SocketAddr)> {
-        self.accept_std().and_then(|(stream, addr)| {
+        self.inner.accept().and_then(|(stream, addr)| {
             let stream = TcpStream::from_std_stream(stream)?;
             Ok((stream, addr))
         })
-    }
-
-    /// Accepts a new `std::net::TcpStream`.
-    ///
-    /// This method is the same as `accept`, except that it returns a TCP socket
-    /// *in blocking mode* which isn't bound to `mio`. This can be later then
-    /// converted to a `mio` type, if necessary.
-    pub fn accept_std(&mut self) -> io::Result<(net::TcpStream, SocketAddr)> {
-        self.inner.accept()
     }
 
     /// Returns the local socket address of this listener.

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -140,7 +140,8 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    pub fn new(listener: net::TcpListener) -> io::Result<TcpListener> {
+    pub fn new(address: SocketAddr) -> io::Result<TcpListener> {
+        let listener = net::TcpListener::bind(address)?;
         listener.set_nonblocking(true)?;
         Ok(TcpListener { listener })
     }

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -28,11 +28,6 @@ impl TcpStream {
         Ok(TcpStream { stream })
     }
 
-    pub fn from_std_stream(stream: net::TcpStream) -> io::Result<TcpStream> {
-        stream.set_nonblocking(true)?;
-        Ok(TcpStream { stream })
-    }
-
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.stream.peer_addr()
     }
@@ -150,8 +145,10 @@ impl TcpListener {
         self.listener.local_addr()
     }
 
-    pub fn accept(&self) -> io::Result<(net::TcpStream, SocketAddr)> {
-        self.listener.accept()
+    pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
+        let (stream, address) = self.listener.accept()?;
+        stream.set_nonblocking(true)?;
+        Ok((TcpStream { stream }, address))
     }
 
     pub fn set_ttl(&mut self, ttl: u32) -> io::Result<()> {


### PR DESCRIPTION
Mostly removing mentions of net2, although it's still used. And remove some API around using the `TcpStream` from the standard library.