### PR TITLE
Enable IPv6 on Travis CI

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -10,8 +10,6 @@ FEATURES=""
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	FEATURES="$FEATURES disable_test_deadline"
-elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-	FEATURES="$FEATURES disable_test_ipv6"
 fi
 
 cargo test --verbose --features "$FEATURES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ rust:
   - stable
   - beta
   - nightly
+# Enable IPv6 on Linux machines.
+before_script: [ "$TRAVIS_OS_NAME" = "linux" ] && sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 script: .ci/test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,6 @@ env_logger = "0.6.0"
 default = ["std"]
 # Enable things that require the standard library, such as OsQueue.
 std = []
-# Travis doesn't support IPv6, so we disable the tests for it.
-disable_test_ipv6 = []
 # Travis' macOS machines don't always meet the set deadline, this disables the
 # tests with strict deadlines.
 disable_test_deadline = []

--- a/tests/tcp_listener.rs
+++ b/tests/tcp_listener.rs
@@ -51,7 +51,6 @@ fn tcp_listener() {
 }
 
 #[test]
-#[cfg_attr(feature="disable_test_ipv6", ignore = "skipping IPv6 test")]
 fn tcp_listener_ipv6() {
     let (mut os_queue, mut events) = init_with_os_queue();
 

--- a/tests/tcp_stream.rs
+++ b/tests/tcp_stream.rs
@@ -62,7 +62,6 @@ fn tcp_stream() {
 }
 
 #[test]
-#[cfg_attr(feature="disable_test_ipv6", ignore = "skipping IPv6 test")]
 fn tcp_stream_ipv6() {
     let (mut os_queue, mut events) = init_with_os_queue();
 

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -81,7 +81,6 @@ fn udp_socket() {
 }
 
 #[test]
-#[cfg_attr(feature="disable_test_ipv6", ignore = "skipping IPv6 test")]
 fn udp_socket_ipv6() {
     let (mut os_queue, mut events) = init_with_os_queue();
 
@@ -199,7 +198,6 @@ fn connected_udp_socket() {
 }
 
 #[test]
-#[cfg_attr(feature="disable_test_ipv6", ignore = "skipping IPv6 test")]
 fn connected_udp_socket_ipv6() {
     let (mut os_queue, mut events) = init_with_os_queue();
 


### PR DESCRIPTION
And enable the IPv6 related tests.

Closes #35.