### PR TITLE
Rename event::Source::next_event_available

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -27,13 +27,13 @@ use core::time::Duration;
 /// struct MyEventSource(Vec<Event>);
 ///
 /// /// The error returned by our even source implementation.
-/// struct MyError;
+/// struct SourceError;
 ///
 /// impl<ES, E> event::Source<ES, E> for MyEventSource
 ///     where ES: event::Sink, // We keep the event sink generic to support all
 ///                            // kinds of event sinks.
-///           E: From<MyError>, // We add this bound to allow use to convert
-///                             // `MyError` into the generic error `E`.
+///           E: From<SourceError>, // We add this bound to allow use to convert
+///                                 // `SourceError` into the generic error `E`.
 /// {
 ///     fn max_timeout(&self) -> Option<Duration> {
 ///         if !self.0.is_empty() {
@@ -56,22 +56,24 @@ use core::time::Duration;
 ///         }
 ///     }
 /// }
-/// # fn poll_events<ES>(_event_sink: &mut ES) -> Result<(), MyError> { Ok(()) }
+/// # fn poll_events<ES>(_event_sink: &mut ES) -> Result<(), SourceError> { Ok(()) }
 ///
-/// // Implementing `From` for `()` allows us to use it as an error in our call
-/// // to poll below..
-/// impl From<MyError> for () {
-///     fn from(_err: MyError) -> () {
-///         ()
+/// #[derive(Debug)]
+/// struct MyError;
+///
+/// // Implementing `From` for `MyError` allows us to use it as an error in our call
+/// // to poll below.
+/// impl From<SourceError> for MyError {
+///     fn from(_err: SourceError) -> MyError {
+///         MyError
 ///     }
 /// }
 ///
-/// # fn main() -> Result<(), ()> {
-/// // Now can use our event source with `()` as error type.
+/// # fn main() -> Result<(), MyError> {
+/// // Now we can use our event source with `MyError` as error type.
 /// let mut my_source = MyEventSource(Vec::new());
 /// let mut events = Vec::new();
-/// poll::<_, ()>(&mut [&mut my_source], &mut events, None)?;
-/// # Ok(())
+/// poll(&mut [&mut my_source], &mut events, None)
 /// # }
 /// ```
 pub trait Source<ES, E>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ pub use crate::os::OsQueue;
 /// #     where ES: event::Sink,
 /// #           E: From<SourceError1>,
 /// # {
-/// #     fn next_event_available(&self) -> Option<Duration> {
+/// #     fn max_timeout(&self) -> Option<Duration> {
 /// #         None
 /// #     }
 /// #
@@ -290,7 +290,7 @@ pub use crate::os::OsQueue;
 /// #     where ES: event::Sink,
 /// #           E: From<SourceError2>,
 /// # {
-/// #     fn next_event_available(&self) -> Option<Duration> {
+/// #     fn max_timeout(&self) -> Option<Duration> {
 /// #         None
 /// #     }
 /// #
@@ -351,7 +351,7 @@ pub fn poll<ES, E>(
 
     // Compute the maximum timeout we can use.
     let timeout = event_sources.iter().fold(timeout, |timeout, event_source| {
-        min_timeout(timeout, event_source.next_event_available())
+        min_timeout(timeout, event_source.max_timeout())
     });
 
     let mut iter = event_sources.iter_mut();

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -421,7 +421,7 @@ impl<ES, E> event::Source<ES, E> for OsQueue
     where ES: event::Sink,
           E: From<io::Error>,
 {
-    fn next_event_available(&self) -> Option<Duration> {
+    fn max_timeout(&self) -> Option<Duration> {
         // Can't tell if an event is available.
         None
     }

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -104,7 +104,7 @@ impl Timers {
 impl<ES, E> event::Source<ES, E> for Timers
     where ES: event::Sink,
 {
-    fn next_event_available(&self) -> Option<Duration> {
+    fn max_timeout(&self) -> Option<Duration> {
         self.deadlines.peek().map(|deadline| {
             let now = Instant::now();
             if deadline.0.deadline <= now {

--- a/src/user_space.rs
+++ b/src/user_space.rs
@@ -58,7 +58,7 @@ impl Queue {
 impl<ES, E> event::Source<ES, E> for Queue
     where ES: event::Sink,
 {
-    fn next_event_available(&self) -> Option<Duration> {
+    fn max_timeout(&self) -> Option<Duration> {
         if !self.events.is_empty() {
             Some(Duration::from_millis(0))
         } else {

--- a/tests/os.rs
+++ b/tests/os.rs
@@ -9,7 +9,7 @@ use mio_st::unix::new_pipe;
 
 mod util;
 
-use self::util::{assert_error, next_event_available, expect_no_events, expect_events, init, init_with_os_queue, EventsCapacity, TIMEOUT_MARGIN};
+use self::util::{assert_error, max_timeout, expect_no_events, expect_events, init, init_with_os_queue, EventsCapacity, TIMEOUT_MARGIN};
 
 struct TestEvented {
     registrations: Vec<(event::Id, Interests, RegisterOption)>,
@@ -114,7 +114,7 @@ fn os_queue_empty_source() {
     let (mut os_queue, mut events) = init_with_os_queue();
 
     // Test `poll` first.
-    assert_eq!(next_event_available(&mut os_queue), None);
+    assert_eq!(max_timeout(&mut os_queue), None);
     event::Source::<_, io::Error>::poll(&mut os_queue, &mut events).unwrap();
     assert!(events.is_empty(), "unexpected events");
 

--- a/tests/poll.rs
+++ b/tests/poll.rs
@@ -12,7 +12,7 @@ struct SleepySource;
 impl<ES, E> event::Source<ES, E> for SleepySource
     where ES: event::Sink,
 {
-    fn next_event_available(&self) -> Option<Duration> {
+    fn max_timeout(&self) -> Option<Duration> {
         None
     }
 
@@ -32,7 +32,7 @@ struct AvailableSource(Duration);
 impl<ES, E> event::Source<ES, E> for AvailableSource
     where ES: event::Sink,
 {
-    fn next_event_available(&self) -> Option<Duration> {
+    fn max_timeout(&self) -> Option<Duration> {
         Some(self.0)
     }
 
@@ -72,7 +72,7 @@ impl<E2, ES, E> event::Source<ES, E> for ResultSource<E2>
           E: From<E2>,
           E2: Clone,
 {
-    fn next_event_available(&self) -> Option<Duration> {
+    fn max_timeout(&self) -> Option<Duration> {
         None
     }
 

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -5,7 +5,7 @@ use mio_st::{Event, Queue};
 
 mod util;
 
-use self::util::{init, next_event_available, expect_events, EventsCapacity};
+use self::util::{init, max_timeout, expect_events, EventsCapacity};
 
 #[test]
 fn queue() {
@@ -13,12 +13,12 @@ fn queue() {
     let mut queue = Queue::new();
     let mut events = Vec::new();
 
-    assert_eq!(next_event_available(&mut queue), None);
+    assert_eq!(max_timeout(&mut queue), None);
 
     // Single event.
     let event = Event::new(event::Id(0), Ready::READABLE);
     queue.add(event);
-    assert_eq!(next_event_available(&mut queue), Some(Duration::from_millis(0)));
+    assert_eq!(max_timeout(&mut queue), Some(Duration::from_millis(0)));
     expect_events(&mut queue, &mut events, vec![event]);
 
     // Multiple events.
@@ -26,7 +26,7 @@ fn queue() {
     queue.add(Event::new(event::Id(0), Ready::WRITABLE));
     queue.add(Event::new(event::Id(0), Ready::READABLE | Ready::WRITABLE));
     queue.add(Event::new(event::Id(1), Ready::READABLE | Ready::WRITABLE | Ready::ERROR));
-    assert_eq!(next_event_available(&mut queue), Some(Duration::from_millis(0)));
+    assert_eq!(max_timeout(&mut queue), Some(Duration::from_millis(0)));
     expect_events(&mut queue, &mut events, vec![
         Event::new(event::Id(0), Ready::READABLE),
         Event::new(event::Id(0), Ready::WRITABLE),

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -33,12 +33,12 @@ pub fn init_with_os_queue() -> (OsQueue, Vec<Event>) {
     (os_queue, Vec::new())
 }
 
-/// Get the next available event with having to worry about the generic
+/// Determine the maximum timeout with having to worry about the generic
 /// parameters.
-pub fn next_event_available<ES>(event_source: &ES) -> Option<Duration>
+pub fn max_timeout<ES>(event_source: &ES) -> Option<Duration>
     where ES: event::Source<Vec<Event>, io::Error>,
 {
-    event_source.next_event_available()
+    event_source.max_timeout()
 }
 
 /// Poll `event_source` and compare the retrieved events with the `expected`


### PR DESCRIPTION
To event::Source::max_timeout.

Closes #63.