### PR TITLE
Add user_space feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
   - rust: stable
     name: "Build check no features"
     script: cargo build --no-default-features
+  - rust: nightly
+    name: "Build check user_space feature"
+    script: cargo build --no-default-features --features user_space
 language: rust
 rust:
   - 1.33.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ env_logger = "0.6.0"
 default = ["std"]
 # Enable things that require the standard library, such as OsQueue.
 std = []
+# **Experimental** feature that enable user space queues. Works in a no_std
+# environment, but requires the alloc crate, which going to be stabilised in
+# 1.36.
+user_space = []
 # Travis' macOS machines don't always meet the set deadline, this disables the
 # tests with strict deadlines.
 disable_test_deadline = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(not(feature = "std"), feature = "user_space"))]
+extern crate alloc;
+
 use core::cmp::min;
 use core::time::Duration;
 
@@ -154,7 +157,7 @@ use log::trace;
 mod sys;
 #[cfg(feature = "std")]
 mod timers;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "user_space"))]
 mod user_space;
 
 pub mod event;
@@ -175,7 +178,7 @@ pub mod unix {
 
 #[cfg(feature = "std")]
 pub use crate::timers::Timers;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "user_space"))]
 pub use crate::user_space::Queue;
 
 #[doc(no_inline)]

--- a/src/user_space.rs
+++ b/src/user_space.rs
@@ -1,6 +1,9 @@
 //! Module with user space readiness event queue.
 
-use std::time::Duration;
+#[cfg(all(not(feature = "std"), feature = "user_space"))]
+use alloc::vec::Vec;
+
+use core::time::Duration;
 
 use log::trace;
 


### PR DESCRIPTION
This allows the user space Queue to be used in a no_std environment. It is currently experimental as it requires the alloc crate which is only available on nightly, to be stabilised in 1.36.