### PR TITLE
Add support of vectored I/O

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -6,7 +6,7 @@ set -x
 cargo --version
 rustc --version
 
-FEATURES=""
+FEATURES="$1"
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 	FEATURES="$FEATURES disable_test_deadline"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
   fast_finish: false
   include:
   - rust: nightly
-    name: "Testing nightly feature"
-    script: cargo test --verbose --features nightly
+    name: "Test nightly feature"
+    script: .ci/test.sh nightly
   - rust: stable
     name: "Build check Linux musl"
     script: .ci/build_check.sh "x86_64-unknown-linux-musl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
 matrix:
   fast_finish: false
   include:
+  - rust: nightly
+    name: "Testing nightly feature"
+    script: cargo test --verbose --features nightly
   - rust: stable
     name: "Build check Linux musl"
     script: .ci/build_check.sh "x86_64-unknown-linux-musl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ user_space = []
 # Travis' macOS machines don't always meet the set deadline, this disables the
 # tests with strict deadlines.
 disable_test_deadline = []
+# Enables features only available in nightly builds of the Rust compiler.
+nightly = []

--- a/src/sys/unix/pipe.rs
+++ b/src/sys/unix/pipe.rs
@@ -1,5 +1,7 @@
 use std::fs::File;
 use std::io::{self, Read, Write};
+#[cfg(feature = "nightly")]
+use std::io::{IoSlice, IoSliceMut};
 use std::mem;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
@@ -131,6 +133,11 @@ impl Read for Receiver {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }
+
+    #[cfg(feature = "nightly")]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
+        self.inner.read_vectored(bufs)
+    }
 }
 
 /// Sending end of an unix pipe.
@@ -177,6 +184,11 @@ impl IntoRawFd for Sender {
 impl Write for Sender {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.inner.write(buf)
+    }
+
+    #[cfg(feature = "nightly")]
+    fn write_vectored(&mut self, bufs: &[IoSlice]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/sys/unix/tcp.rs
+++ b/src/sys/unix/tcp.rs
@@ -1,4 +1,6 @@
 use std::io::{self, Read, Write};
+#[cfg(feature = "nightly")]
+use std::io::{IoSlice, IoSliceMut};
 use std::mem::size_of_val;
 use std::net::{self, SocketAddr};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -98,11 +100,21 @@ impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.stream.read(buf)
     }
+
+    #[cfg(feature = "nightly")]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
+        self.stream.read_vectored(bufs)
+    }
 }
 
 impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.stream.write(buf)
+    }
+
+    #[cfg(feature = "nightly")]
+    fn write_vectored(&mut self, bufs: &[IoSlice]) -> io::Result<usize> {
+        self.stream.write_vectored(bufs)
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
This also introduces an nightly feature, disabled by default, to allow for testing nightly only features.